### PR TITLE
refactor(src): 优化 beforeResolving、resolving 和 afterResolving 方法的参数类型

### DIFF
--- a/src/Wrapper/LaravelContainerWrapper.php
+++ b/src/Wrapper/LaravelContainerWrapper.php
@@ -188,7 +188,7 @@ final class LaravelContainerWrapper extends Container
     /**
      * @inheritDoc
      */
-    public function beforeResolving($abstract, Closure $callback = null)
+    public function beforeResolving($abstract, ?Closure $callback = null)
     {
         return $this->__call(__FUNCTION__, func_get_args());
     }
@@ -196,7 +196,7 @@ final class LaravelContainerWrapper extends Container
     /**
      * @inheritDoc
      */
-    public function resolving($abstract, Closure $callback = null)
+    public function resolving($abstract, ?Closure $callback = null)
     {
         return $this->__call(__FUNCTION__, func_get_args());
     }
@@ -204,7 +204,7 @@ final class LaravelContainerWrapper extends Container
     /**
      * @inheritDoc
      */
-    public function afterResolving($abstract, Closure $callback = null)
+    public function afterResolving($abstract, ?Closure $callback = null)
     {
         return $this->__call(__FUNCTION__, func_get_args());
     }


### PR DESCRIPTION
- 为 beforeResolving、resolving 和 afterResolving 方法的 $callback 参数添加 ?Closure 类型提示 -允许 $callback 参数为 null，提高代码灵活性和类型安全性